### PR TITLE
Content-Type multipart/form-data header should also be proxied

### DIFF
--- a/src/WireMock.Net/Http/ByteArrayContentHelper.cs
+++ b/src/WireMock.Net/Http/ByteArrayContentHelper.cs
@@ -2,7 +2,6 @@
 
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Stef.Validation;
 
 namespace WireMock.Http;
 
@@ -16,8 +15,6 @@ internal static class ByteArrayContentHelper
     /// <returns>ByteArrayContent</returns>
     internal static ByteArrayContent Create(byte[] content, MediaTypeHeaderValue? contentType)
     {
-        Guard.NotNull(content);
-
         var byteContent = new ByteArrayContent(content);
         if (contentType != null)
         {

--- a/src/WireMock.Net/Http/HttpRequestMessageHelper.cs
+++ b/src/WireMock.Net/Http/HttpRequestMessageHelper.cs
@@ -37,10 +37,11 @@ internal static class HttpRequestMessageHelper
         var bodyData = requestMessage.BodyData;
         httpRequestMessage.Content = bodyData?.GetBodyType() switch
         {
-            BodyType.Bytes => ByteArrayContentHelper.Create(bodyData!.BodyAsBytes!, contentType),
-            BodyType.Json => StringContentHelper.Create(JsonConvert.SerializeObject(bodyData!.BodyAsJson), contentType),
-            BodyType.String => StringContentHelper.Create(bodyData!.BodyAsString!, contentType),
-            BodyType.FormUrlEncoded => StringContentHelper.Create(bodyData!.BodyAsString!, contentType),
+            BodyType.Bytes => ByteArrayContentHelper.Create(bodyData.BodyAsBytes!, contentType),
+            BodyType.Json => StringContentHelper.Create(JsonConvert.SerializeObject(bodyData.BodyAsJson), contentType),
+            BodyType.String => StringContentHelper.Create(bodyData.BodyAsString!, contentType),
+            BodyType.FormUrlEncoded => StringContentHelper.Create(bodyData.BodyAsString!, contentType),
+            BodyType.MultiPart => StringContentHelper.Create(bodyData.BodyAsString!, contentType),
 
             _ => httpRequestMessage.Content
         };

--- a/src/WireMock.Net/Http/StringContentHelper.cs
+++ b/src/WireMock.Net/Http/StringContentHelper.cs
@@ -2,7 +2,6 @@
 
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Stef.Validation;
 
 namespace WireMock.Http;
 
@@ -16,8 +15,6 @@ internal static class StringContentHelper
     /// <returns>StringContent</returns>
     internal static StringContent Create(string content, MediaTypeHeaderValue? contentType)
     {
-        Guard.NotNull(content);
-
         var stringContent = new StringContent(content);
         stringContent.Headers.ContentType = contentType;
         return stringContent;


### PR DESCRIPTION
## Submitter checklist



- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
