### PR TITLE
Fix errors when converting response bodies with top-level JSON arrays to C# code

### DIFF
--- a/src/WireMock.Net/Util/CSharpFormatter.cs
+++ b/src/WireMock.Net/Util/CSharpFormatter.cs
@@ -96,13 +96,13 @@ internal static class CSharpFormatter
         "while"
     });
     #endregion
-    
+
     public static object ConvertToAnonymousObjectDefinition(object jsonBody, int ind = 2)
     {
         var serializedBody = JsonConvert.SerializeObject(jsonBody);
         using var jsonReader = new JsonTextReader(new StringReader(serializedBody));
         jsonReader.DateParseHandling = DateParseHandling.None;
-        var deserializedBody = JObject.Load(jsonReader);
+        var deserializedBody = JToken.Load(jsonReader);
 
         return ConvertJsonToAnonymousObjectDefinition(deserializedBody, ind);
     }


### PR DESCRIPTION
When trying to convert static mapping to C# code, I ran into an exception when the body is a top-level array rather than a pure string or a (non-array) JSON object.

The problem is that this code doesn't distinguish between arrays and objects, and assumes that every non-null that isn't a string is an object:
```cs
case BodyType.Json:
    if (bodyData.BodyAsJson is string bodyStringValue)
    {
        sb.AppendLine($"        .WithBody({ToCSharpStringLiteral(bodyStringValue)})");
    }
    else if (bodyData.BodyAsJson is { } jsonBody)
    {
        var anonymousObjectDefinition = ConvertToAnonymousObjectDefinition(jsonBody);
        sb.AppendLine($"        .WithBodyAsJson({anonymousObjectDefinition})");
    }
                                                                                      
    break;
```

My solution is to load a JToken instead of a JObject in ConvertToAnonymousObjectDefinition, which seems like the original intention given that ConvertJsonToAnonymousObjectDefinition (which is defined in an internal class) expects a JToken and isn't called anywhere else in the code.