### PR TITLE
Bump Testcontainers version to 4.5.0

### DIFF
--- a/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
+++ b/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
@@ -39,11 +39,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Stef.Validation" Version="0.1.1" />
-        <PackageReference Include="Testcontainers" Version="4.0.0" />
+        <PackageReference Include="Testcontainers" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\WireMock.Net.RestClient\WireMock.Net.RestClient.csproj" />
     </ItemGroup>
-    
+
 </Project>

--- a/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.cs
+++ b/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.cs
@@ -123,7 +123,11 @@ public partial class TestcontainersTests
         }
         finally
         {
-            await wireMockContainer.StopAsync();
+            // Stop the container
+            if(wireMockContainer is not null)
+            {
+                await wireMockContainer.StopAsync();
+            }
         }
     }
 }

--- a/test/WireMock.Net.Tests/WireMock.Net.Tests.csproj
+++ b/test/WireMock.Net.Tests/WireMock.Net.Tests.csproj
@@ -102,7 +102,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
-        <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
+        <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
         <PackageReference Include="JsonConverter.System.Text.Json" Version="0.7.0" />
         <PackageReference Include="Google.Protobuf" Version="3.25.1" />
         <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />


### PR DESCRIPTION
The Testcontainers dependency Docker.DotNet was bumped to 3.128.1 and is not binary compatible with previous version. When a user has a direct dependency on Testcontainers 4.5.0, WireMock.Net.Testcontainers fails with :

```plain
System.MissingMethodException : Method not found: 'Docker.DotNet.DockerClient Docker.DotNet.DockerClientConfiguration.CreateClient(System.Version)'
```

<!-- Please describe your pull request here. -->

## References

- #1310

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
