### PR TITLE
Use default resource cleaning behavior in test

### DIFF
--- a/examples/WireMock.Net.TestcontainersExample/Program.cs
+++ b/examples/WireMock.Net.TestcontainersExample/Program.cs
@@ -159,9 +159,7 @@ internal class Program
     private static async Task TestWindowsCopyAsync()
     {
         var builder = new WireMockContainerBuilder()
-            .WithWatchStaticMappings(true)
-            .WithAutoRemove(true)
-            .WithCleanUp(true);
+            .WithWatchStaticMappings(true);
 
         var container = builder.Build();
 
@@ -186,8 +184,6 @@ internal class Program
         var mappings = await adminClient.GetMappingsAsync();
         Console.WriteLine("mappings = " + JsonConvert.SerializeObject(mappings, Formatting.Indented));
 
-        await Task.Delay(1_000);
-
         await container.StopAsync();
     }
 
@@ -205,9 +201,7 @@ internal class Program
             .WithNetwork(dummyNetwork)
             .WithAdminUserNameAndPassword("x", "y")
             .WithMappings(mappingsPath)
-            .WithWatchStaticMappings(true)
-            // .WithAutoRemove(true)
-            .WithCleanUp(true);
+            .WithWatchStaticMappings(true);
 
         if (image != null)
         {

--- a/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.Grpc.cs
+++ b/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.Grpc.cs
@@ -25,8 +25,6 @@ public partial class TestcontainersTests
         var adminUsername = $"username_{Guid.NewGuid()}";
         var adminPassword = $"password_{Guid.NewGuid()}";
         var wireMockContainer = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .WithAdminUserNameAndPassword(adminUsername, adminPassword)
             .WithCommand("--UseHttp2")
             .WithCommand("--Urls", "http://*:80 grpc://*:9090")
@@ -80,8 +78,6 @@ public partial class TestcontainersTests
         var adminUsername = $"username_{Guid.NewGuid()}";
         var adminPassword = $"password_{Guid.NewGuid()}";
         var wireMockContainer = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .WithAdminUserNameAndPassword(adminUsername, adminPassword)
             .AddUrl("http://*:8080")
             .AddUrl("grpc://*:9090")
@@ -156,8 +152,6 @@ public partial class TestcontainersTests
     private static async Task<WireMockContainer> Given_WireMockContainerIsStartedForHttpAndGrpcAsync()
     {
         var wireMockContainer = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .AddUrl("grpc://*:9090")
             .Build();
 
@@ -169,8 +163,6 @@ public partial class TestcontainersTests
     private static async Task<WireMockContainer> Given_WireMockContainerWithProtoDefinitionAtServerLevelIsStartedForHttpAndGrpcAsync()
     {
         var wireMockContainer = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .AddUrl("grpc://*:9090")
             .AddProtoDefinition("my-greeter", ReadFile("greet.proto"))
             .Build();

--- a/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.cs
+++ b/test/WireMock.Net.Tests/Testcontainers/TestcontainersTests.cs
@@ -24,8 +24,6 @@ public partial class TestcontainersTests(ITestOutputHelper testOutputHelper)
         var adminUsername = $"username_{Guid.NewGuid()}";
         var adminPassword = $"password_{Guid.NewGuid()}";
         var wireMockContainer = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .WithAdminUserNameAndPassword(adminUsername, adminPassword)
             .Build();
 
@@ -40,14 +38,11 @@ public partial class TestcontainersTests(ITestOutputHelper testOutputHelper)
         // Act
         var dummyNetwork = new NetworkBuilder()
             .WithName("Dummy Network for TestcontainersTests")
-            .WithCleanUp(true)
             .Build();
 
         var wireMockContainer = new WireMockContainerBuilder()
             .WithNetwork(dummyNetwork)
             .WithWatchStaticMappings(true)
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .Build();
 
         await StartTestAsync(wireMockContainer);
@@ -61,8 +56,6 @@ public partial class TestcontainersTests(ITestOutputHelper testOutputHelper)
         var adminUsername = $"username_{Guid.NewGuid()}";
         var adminPassword = $"password_{Guid.NewGuid()}";
         var wireMockContainerBuilder = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .WithAdminUserNameAndPassword(adminUsername, adminPassword);
 
         var imageOS = await TestcontainersUtils.GetImageOSAsync.Value;
@@ -88,8 +81,6 @@ public partial class TestcontainersTests(ITestOutputHelper testOutputHelper)
         var adminUsername = $"username_{Guid.NewGuid()}";
         var adminPassword = $"password_{Guid.NewGuid()}";
         var wireMockContainerBuilder = new WireMockContainerBuilder()
-            .WithAutoRemove(true)
-            .WithCleanUp(true)
             .WithAdminUserNameAndPassword(adminUsername, adminPassword);
 
         var imageOS = await TestcontainersUtils.GetImageOSAsync.Value;


### PR DESCRIPTION
Remove unecessary call to `AutoRemove()`, `CleanUp()` to not mislead users of WireMock.Net.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
