### PR TITLE
Fixes an issue with matching JSON bodies as bytes

### DIFF
--- a/src/WireMock.Net.Shared/Matchers/Helpers/BodyDataMatchScoreCalculator.cs
+++ b/src/WireMock.Net.Shared/Matchers/Helpers/BodyDataMatchScoreCalculator.cs
@@ -34,14 +34,10 @@ internal static class BodyDataMatchScoreCalculator
             }
         }
 
-        if (matcher is ExactObjectMatcher exactObjectMatcher)
+        if (matcher is ExactObjectMatcher { Value: byte[] } exactObjectMatcher)
         {
             // If the body is a byte array, try to match.
-            var detectedBodyType = requestMessage.DetectedBodyType;
-            if (detectedBodyType is BodyType.Bytes or BodyType.String or BodyType.FormUrlEncoded || exactObjectMatcher.Value is byte[])
-            {
-                return exactObjectMatcher.IsMatch(requestMessage.BodyAsBytes);
-            }
+            return exactObjectMatcher.IsMatch(requestMessage.BodyAsBytes);
         }
 
         // Check if the matcher is a IObjectMatcher

--- a/src/WireMock.Net.Shared/Matchers/Helpers/BodyDataMatchScoreCalculator.cs
+++ b/src/WireMock.Net.Shared/Matchers/Helpers/BodyDataMatchScoreCalculator.cs
@@ -38,7 +38,7 @@ internal static class BodyDataMatchScoreCalculator
         {
             // If the body is a byte array, try to match.
             var detectedBodyType = requestMessage.DetectedBodyType;
-            if (detectedBodyType is BodyType.Bytes or BodyType.String or BodyType.FormUrlEncoded)
+            if (detectedBodyType is BodyType.Bytes or BodyType.String or BodyType.FormUrlEncoded || exactObjectMatcher.Value is byte[])
             {
                 return exactObjectMatcher.IsMatch(requestMessage.BodyAsBytes);
             }

--- a/test/WireMock.Net.Tests/RequestMatchers/RequestMessageBodyMatcherTests.cs
+++ b/test/WireMock.Net.Tests/RequestMatchers/RequestMessageBodyMatcherTests.cs
@@ -405,6 +405,79 @@ public class RequestMessageBodyMatcherTests
     }
 
     [Theory]
+    [InlineData(new byte[] { 1 })]
+    [InlineData(new byte[] { 48 })]
+    public void RequestMessageBodyMatcher_GetMatchingScore_BodyTypeBytes_BodyAsBytes_ExactObjectMapper(byte[] bytes)
+    {
+        // Assign
+        var body = new BodyData
+        {
+            BodyAsBytes = bytes,
+            DetectedBodyType = BodyType.Bytes
+        };
+        var exactObjectMapper = new ExactObjectMatcher(bytes);
+
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), "GET", "127.0.0.1", body);
+
+        var matcher = new RequestMessageBodyMatcher(exactObjectMapper);
+
+        // Act
+        var result = new RequestMatchResult();
+        double score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        Check.That(score).IsEqualTo(1.0d);
+    }
+
+    [Fact]
+    public void RequestMessageBodyMatcher_GetMatchingScore_BodyTypeString_BodyAsBytes_ExactObjectMapper()
+    {
+        // Assign
+        var bytes = Encoding.UTF8.GetBytes("hello");
+        var body = new BodyData
+        {
+            BodyAsBytes = bytes,
+            DetectedBodyType = BodyType.String
+        };
+        var exactObjectMapper = new ExactObjectMatcher(bytes);
+
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), "GET", "127.0.0.1", body);
+
+        var matcher = new RequestMessageBodyMatcher(exactObjectMapper);
+
+        // Act
+        var result = new RequestMatchResult();
+        double score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        Check.That(score).IsEqualTo(1.0d);
+    }
+
+    [Fact]
+    public void RequestMessageBodyMatcher_GetMatchingScore_BodyTypeJson_BodyAsBytes_ExactObjectMapper()
+    {
+        // Assign
+        var bytes = Encoding.UTF8.GetBytes("""{"value":42}""");
+        var body = new BodyData
+        {
+            BodyAsBytes = bytes,
+            DetectedBodyType = BodyType.Json
+        };
+        var exactObjectMapper = new ExactObjectMatcher(bytes);
+
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), "GET", "127.0.0.1", body);
+
+        var matcher = new RequestMessageBodyMatcher(exactObjectMapper);
+
+        // Act
+        var result = new RequestMatchResult();
+        double score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        Check.That(score).IsEqualTo(1.0d);
+    }
+
+    [Theory]
     [MemberData(nameof(MatchingScoreData))]
     public async Task RequestMessageBodyMatcher_GetMatchingScore_Funcs_Matching(object body, RequestMessageBodyMatcher matcher, bool shouldMatch)
     {
@@ -459,13 +532,13 @@ public class RequestMessageBodyMatcherTests
                 {json, new RequestMessageBodyMatcher((object? o) => ((dynamic) o!).a == "b"), true},
                 {json, new RequestMessageBodyMatcher((string? s) => s == json), true},
                 {json, new RequestMessageBodyMatcher((byte[]? b) => b?.SequenceEqual(Encoding.UTF8.GetBytes(json)) == true), true},
-                
+
                 // JSON no match ---
                 {json, new RequestMessageBodyMatcher((object? o) => false), false},
                 {json, new RequestMessageBodyMatcher((string? s) => false), false},
                 {json, new RequestMessageBodyMatcher((byte[]? b) => false), false},
                 {json, new RequestMessageBodyMatcher(), false },
-                
+
                 // string match +++
                 {str, new RequestMessageBodyMatcher((object? o) => o == null), true},
                 {str, new RequestMessageBodyMatcher((string? s) => s == str), true},
@@ -476,7 +549,7 @@ public class RequestMessageBodyMatcherTests
                 {str, new RequestMessageBodyMatcher((string? s) => false), false},
                 {str, new RequestMessageBodyMatcher((byte[]? b) => false), false},
                 {str, new RequestMessageBodyMatcher(), false },
-                
+
                 // binary match +++
                 {bytes, new RequestMessageBodyMatcher((object? o) => o == null), true},
                 {bytes, new RequestMessageBodyMatcher((string? s) => s == null), true},


### PR DESCRIPTION
Fixes an issue where body payloads would fail to be matched if the matcher was created using a `byte[]` value and the bytes represented valid JSON.

## References

- #1338 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
