### PR TITLE
Soft max request log count enabled

### DIFF
--- a/src/WireMock.Net.Abstractions/Admin/Settings/SettingsModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Settings/SettingsModel.cs
@@ -35,6 +35,12 @@ public class SettingsModel
     public int? MaxRequestLogCount { get; set; }
 
     /// <summary>
+    /// Gets or sets whether MaxRequestLogCount should be enforced using a background timer
+    /// instead of trimming synchronously on each request.
+    /// </summary>
+    public bool? SoftMaxRequestLogCountEnabled { get; set; }
+
+    /// <summary>
     /// Allow a Body for all HTTP Methods. (default set to <c>false</c>).
     /// </summary>
     public bool? AllowBodyForAllHttpMethods { get; set; }

--- a/src/WireMock.Net.Minimal/Owin/IWireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net.Minimal/Owin/IWireMockMiddlewareOptions.cs
@@ -41,6 +41,8 @@ internal interface IWireMockMiddlewareOptions
 
     int? MaxRequestLogCount { get; set; }
 
+    bool? SoftMaxRequestLogCountEnabled { get; set; }
+
     Action<IAppBuilder>? PreWireMockMiddlewareInit { get; set; }
 
     Action<IAppBuilder>? PostWireMockMiddlewareInit { get; set; }

--- a/src/WireMock.Net.Minimal/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net.Minimal/Owin/WireMockMiddleware.cs
@@ -368,12 +368,20 @@ namespace WireMock.Owin
             }
 
             // In case MaxRequestLogCount has a value greater than 0, try to delete existing request logs based on the count.
+            // Entries are always appended chronologically, so oldest are at the front - no sort needed.
             if (_options.MaxRequestLogCount is > 0 && _options.SoftMaxRequestLogCountEnabled != true)
             {
-                var logEntries = _options.LogEntries.ToList();
-                foreach (var logEntry in logEntries.OrderBy(le => le.RequestMessage.DateTime).Take(logEntries.Count - _options.MaxRequestLogCount.Value))
+                while (_options.LogEntries.Count > _options.MaxRequestLogCount.Value)
                 {
-                    TryRemoveLogEntry(logEntry);
+                    try
+                    {
+                        _options.LogEntries.RemoveAt(0);
+                    }
+                    catch
+                    {
+                        // Ignore exception (can happen during stress testing)
+                        break;
+                    }
                 }
             }
 

--- a/src/WireMock.Net.Minimal/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net.Minimal/Owin/WireMockMiddleware.cs
@@ -368,7 +368,7 @@ namespace WireMock.Owin
             }
 
             // In case MaxRequestLogCount has a value greater than 0, try to delete existing request logs based on the count.
-            if (_options.MaxRequestLogCount is > 0)
+            if (_options.MaxRequestLogCount is > 0 && _options.SoftMaxRequestLogCountEnabled != true)
             {
                 var logEntries = _options.LogEntries.ToList();
                 foreach (var logEntry in logEntries.OrderBy(le => le.RequestMessage.DateTime).Take(logEntries.Count - _options.MaxRequestLogCount.Value))

--- a/src/WireMock.Net.Minimal/Owin/WireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net.Minimal/Owin/WireMockMiddlewareOptions.cs
@@ -39,6 +39,8 @@ internal class WireMockMiddlewareOptions : IWireMockMiddlewareOptions
 
     public int? MaxRequestLogCount { get; set; }
 
+    public bool? SoftMaxRequestLogCountEnabled { get; set; }
+
     public Action<IAppBuilder>? PreWireMockMiddlewareInit { get; set; }
 
     public Action<IAppBuilder>? PostWireMockMiddlewareInit { get; set; }

--- a/src/WireMock.Net.Minimal/Owin/WireMockMiddlewareOptionsHelper.cs
+++ b/src/WireMock.Net.Minimal/Owin/WireMockMiddlewareOptionsHelper.cs
@@ -29,6 +29,7 @@ internal static class WireMockMiddlewareOptionsHelper
         options.HandleRequestsSynchronously = settings.HandleRequestsSynchronously;
         options.Logger = settings.Logger;
         options.MaxRequestLogCount = settings.MaxRequestLogCount;
+        options.SoftMaxRequestLogCountEnabled = settings.SoftMaxRequestLogCountEnabled;
         options.PostWireMockMiddlewareInit = settings.PostWireMockMiddlewareInit;
         options.PreWireMockMiddlewareInit = settings.PreWireMockMiddlewareInit;
         options.QueryParameterMultipleValueSupport = settings.QueryParameterMultipleValueSupport;

--- a/src/WireMock.Net.Minimal/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.Admin.cs
@@ -286,6 +286,7 @@ public partial class WireMockServer
             HandleRequestsSynchronously = _settings.HandleRequestsSynchronously,
             HostingScheme = _settings.HostingScheme,
             MaxRequestLogCount = _settings.MaxRequestLogCount,
+            SoftMaxRequestLogCountEnabled = _settings.SoftMaxRequestLogCountEnabled,
             ProtoDefinitions = _settings.ProtoDefinitions,
             QueryParameterMultipleValueSupport = _settings.QueryParameterMultipleValueSupport,
             ReadStaticMappings = _settings.ReadStaticMappings,
@@ -321,6 +322,7 @@ public partial class WireMockServer
         _settings.DoNotSaveDynamicResponseInLogEntry = settings.DoNotSaveDynamicResponseInLogEntry;
         _settings.HandleRequestsSynchronously = settings.HandleRequestsSynchronously;
         _settings.MaxRequestLogCount = settings.MaxRequestLogCount;
+        _settings.SoftMaxRequestLogCountEnabled = settings.SoftMaxRequestLogCountEnabled;
         _settings.ProtoDefinitions = settings.ProtoDefinitions;
         _settings.ProxyAndRecordSettings = TinyMapperUtils.Instance.Map(settings.ProxyAndRecordSettings);
         _settings.QueryParameterMultipleValueSupport = settings.QueryParameterMultipleValueSupport;

--- a/src/WireMock.Net.Minimal/Server/WireMockServer.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.cs
@@ -46,6 +46,7 @@ public partial class WireMockServer : IWireMockServer
     private readonly MatcherMapper _matcherMapper;
     private readonly MappingToFileSaver _mappingToFileSaver;
     private readonly MappingBuilder _mappingBuilder;
+    private Timer? _softMaxLogTrimTimer;
     private readonly IGuidUtils _guidUtils = new GuidUtils();
     private readonly IDateTimeUtils _dateTimeUtils = new DateTimeUtils();
     private readonly MappingSerializer _mappingSerializer;
@@ -116,6 +117,8 @@ public partial class WireMockServer : IWireMockServer
     /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
     protected virtual void Dispose(bool disposing)
     {
+        _softMaxLogTrimTimer?.Dispose();
+        _softMaxLogTrimTimer = null;
         DisposeEnhancedFileSystemWatcher();
         _httpServer?.StopAsync();
     }
@@ -763,6 +766,40 @@ public partial class WireMockServer : IWireMockServer
         if (settings.MaxRequestLogCount != null)
         {
             SetMaxRequestLogCount(settings.MaxRequestLogCount);
+        }
+
+        // Start or stop the soft max log trim timer based on settings
+        _softMaxLogTrimTimer?.Dispose();
+        _softMaxLogTrimTimer = null;
+        if (settings.SoftMaxRequestLogCountEnabled == true && settings.MaxRequestLogCount is > 0)
+        {
+            _softMaxLogTrimTimer = new Timer(
+                _ => TrimExcessLogEntries(),
+                null,
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private void TrimExcessLogEntries()
+    {
+        try
+        {
+            var maxCount = _options.MaxRequestLogCount;
+            if (maxCount is not > 0) return;
+
+            var logEntries = _options.LogEntries.ToList();
+            var excess = logEntries.Count - maxCount.Value;
+            if (excess <= 0) return;
+
+            foreach (var entry in logEntries.OrderBy(e => e.RequestMessage.DateTime).Take(excess))
+            {
+                try { _options.LogEntries.Remove(entry); } catch { /* concurrent removal is safe */ }
+            }
+        }
+        catch
+        {
+            // Timer callback must never throw -- prevents timer from stopping
         }
     }
 }

--- a/src/WireMock.Net.Minimal/Settings/WireMockServerSettingsParser.cs
+++ b/src/WireMock.Net.Minimal/Settings/WireMockServerSettingsParser.cs
@@ -61,6 +61,7 @@ public static class WireMockServerSettingsParser
             HandleRequestsSynchronously = parser.GetBoolValue(nameof(WireMockServerSettings.HandleRequestsSynchronously)),
             HostingScheme = parser.GetEnumValue<HostingScheme>(nameof(WireMockServerSettings.HostingScheme)),
             MaxRequestLogCount = parser.GetIntValue(nameof(WireMockServerSettings.MaxRequestLogCount)),
+            SoftMaxRequestLogCountEnabled = parser.GetBoolValue(nameof(WireMockServerSettings.SoftMaxRequestLogCountEnabled)),
             ProtoDefinitions = parser.GetObjectValueFromJson<Dictionary<string, string[]>>(nameof(settings.ProtoDefinitions)),
             QueryParameterMultipleValueSupport = parser.GetEnumValue<QueryParameterMultipleValueSupport>(nameof(WireMockServerSettings.QueryParameterMultipleValueSupport)),
             ReadStaticMappings = parser.GetBoolValue(nameof(WireMockServerSettings.ReadStaticMappings)),

--- a/src/WireMock.Net.Minimal/Util/ConcurrentObservableCollection.cs
+++ b/src/WireMock.Net.Minimal/Util/ConcurrentObservableCollection.cs
@@ -77,6 +77,32 @@ internal class ConcurrentObservableCollection<T> : ObservableCollection<T>
         }
     }
 
+    /// <summary>
+    /// Gets the number of elements contained in the collection (thread-safe).
+    /// </summary>
+    public new int Count
+    {
+        get
+        {
+            lock (_lockObject)
+            {
+                return Items.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes the element at the specified index of the collection (thread-safe).
+    /// </summary>
+    /// <param name="index">The zero-based index of the element to remove.</param>
+    public new void RemoveAt(int index)
+    {
+        lock (_lockObject)
+        {
+            base.RemoveItem(index);
+        }
+    }
+
     public List<T> ToList()
     {
         lock (_lockObject)

--- a/src/WireMock.Net.Shared/Settings/WireMockServerSettings.cs
+++ b/src/WireMock.Net.Shared/Settings/WireMockServerSettings.cs
@@ -140,6 +140,14 @@ public class WireMockServerSettings
     public int? MaxRequestLogCount { get; set; }
 
     /// <summary>
+    /// Gets or sets whether MaxRequestLogCount should be enforced using a background timer
+    /// instead of trimming synchronously on each request. When enabled, log trimming happens
+    /// periodically in the background, reducing request processing latency.
+    /// </summary>
+    [PublicAPI]
+    public bool? SoftMaxRequestLogCountEnabled { get; set; }
+
+    /// <summary>
     /// Action which is called (with the IAppBuilder or IApplicationBuilder) before the internal WireMockMiddleware is initialized. [Optional]
     /// </summary>
     [PublicAPI]

--- a/test/WireMock.Net.Tests/WireMockServer.Admin.cs
+++ b/test/WireMock.Net.Tests/WireMockServer.Admin.cs
@@ -428,6 +428,25 @@ public class WireMockServerAdminTests
     }
 
     [Fact]
+    public async Task WireMockServer_Admin_Logging_SetMaxRequestLogCount_HighVolume()
+    {
+        // Arrange
+        using var client = new HttpClient();
+        using var server = WireMockServer.Start();
+        server.SetMaxRequestLogCount(5);
+
+        // Act - send 50 requests
+        for (int i = 0; i < 50; i++)
+        {
+            await client.GetAsync($"http://localhost:{server.Ports[0]}/req{i}").ConfigureAwait(false);
+        }
+
+        // Assert - should have exactly 5 entries, the most recent ones
+        server.LogEntries.Should().HaveCount(5);
+        server.LogEntries.Last().RequestMessage.Path.Should().EndWith("/req49");
+    }
+
+    [Fact]
     public async Task WireMockServer_Admin_Logging_FindLogEntries()
     {
         // Assign

--- a/test/WireMock.Net.Tests/WireMockServer.SoftMax.cs
+++ b/test/WireMock.Net.Tests/WireMockServer.SoftMax.cs
@@ -1,0 +1,151 @@
+// Copyright (c) WireMock.Net
+
+#if !(NET452 || NET461 || NETCOREAPP3_1)
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using WireMock.Logging;
+using WireMock.Owin;
+using WireMock.Server;
+using WireMock.Settings;
+using Xunit;
+
+namespace WireMock.Net.Tests;
+
+public class WireMockServerSoftMaxTests
+{
+    [Fact]
+    public void SoftMaxRequestLogCountEnabled_DefaultsToNull()
+    {
+        // Arrange & Act
+        var settings = new WireMockServerSettings();
+
+        // Assert
+        settings.SoftMaxRequestLogCountEnabled.Should().BeNull();
+    }
+
+    [Fact]
+    public void SoftMaxRequestLogCountEnabled_CanBeSetToTrue()
+    {
+        // Arrange & Act
+        var settings = new WireMockServerSettings
+        {
+            SoftMaxRequestLogCountEnabled = true
+        };
+
+        // Assert
+        settings.SoftMaxRequestLogCountEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SoftMaxRequestLogCountEnabled_CanBeSetToFalse()
+    {
+        // Arrange & Act
+        var settings = new WireMockServerSettings
+        {
+            SoftMaxRequestLogCountEnabled = false
+        };
+
+        // Assert
+        settings.SoftMaxRequestLogCountEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SoftMaxRequestLogCountEnabled_PropagatesFromSettingsToMiddlewareOptions()
+    {
+        // Arrange
+        var settings = new WireMockServerSettings
+        {
+            SoftMaxRequestLogCountEnabled = true,
+            Logger = new WireMockNullLogger()
+        };
+
+        // Act
+        var options = WireMockMiddlewareOptionsHelper.InitFromSettings(settings);
+
+        // Assert
+        options.SoftMaxRequestLogCountEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SoftMaxRequestLogCountEnabled_PropagatesNullFromSettingsToMiddlewareOptions()
+    {
+        // Arrange
+        var settings = new WireMockServerSettings
+        {
+            Logger = new WireMockNullLogger()
+        };
+
+        // Act
+        var options = WireMockMiddlewareOptionsHelper.InitFromSettings(settings);
+
+        // Assert
+        options.SoftMaxRequestLogCountEnabled.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SoftMaxRequestLogCountEnabled_AdminApi_SettingsGet_ReturnsValue()
+    {
+        // Arrange
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            SoftMaxRequestLogCountEnabled = true,
+            StartAdminInterface = true
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+
+            // Act
+            var response = await httpClient.GetStringAsync($"{server.Urls[0]}/__admin/settings");
+            var json = JObject.Parse(response);
+
+            // Assert
+            json["SoftMaxRequestLogCountEnabled"]?.Value<bool>().Should().BeTrue();
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SoftMaxRequestLogCountEnabled_AdminApi_SettingsUpdate_PersistsValue()
+    {
+        // Arrange
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            StartAdminInterface = true
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+
+            // Act - Update the setting
+            var content = new StringContent(
+                "{\"SoftMaxRequestLogCountEnabled\": true}",
+                Encoding.UTF8,
+                "application/json"
+            );
+            var putResponse = await httpClient.PutAsync($"{server.Urls[0]}/__admin/settings", content);
+            putResponse.EnsureSuccessStatusCode();
+
+            // Act - Read back the setting
+            var response = await httpClient.GetStringAsync($"{server.Urls[0]}/__admin/settings");
+            var json = JObject.Parse(response);
+
+            // Assert
+            json["SoftMaxRequestLogCountEnabled"]?.Value<bool>().Should().BeTrue();
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+}
+#endif

--- a/test/WireMock.Net.Tests/WireMockServer.SoftMax.cs
+++ b/test/WireMock.Net.Tests/WireMockServer.SoftMax.cs
@@ -1,6 +1,8 @@
 // Copyright (c) WireMock.Net
 
 #if !(NET452 || NET461 || NETCOREAPP3_1)
+using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -141,6 +143,147 @@ public class WireMockServerSoftMaxTests
 
             // Assert
             json["SoftMaxRequestLogCountEnabled"]?.Value<bool>().Should().BeTrue();
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+    // --- Plan 02: Background timer behavior and compatibility tests ---
+
+    [Fact]
+    public async Task SoftMaxDisabled_InlineTrimStillRunsOnEveryRequest()
+    {
+        // Arrange - SoftMaxRequestLogCountEnabled is NOT set (default null = disabled)
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            MaxRequestLogCount = 3
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            var baseUrl = server.Urls[0];
+
+            // Act - Send 5 requests (exceeds MaxRequestLogCount of 3)
+            for (int i = 0; i < 5; i++)
+            {
+                await httpClient.GetAsync($"{baseUrl}/request{i}");
+            }
+
+            // Assert - Inline trim should have kept count at exactly MaxRequestLogCount
+            server.LogEntries.Count().Should().Be(3);
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SoftMaxEnabled_LogCountCanTemporarilyExceedMax()
+    {
+        // Arrange - SoftMaxRequestLogCountEnabled = true, so inline trim is skipped
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            MaxRequestLogCount = 3,
+            SoftMaxRequestLogCountEnabled = true
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            var baseUrl = server.Urls[0];
+
+            // Act - Send 6 requests quickly (before timer fires)
+            for (int i = 0; i < 6; i++)
+            {
+                await httpClient.GetAsync($"{baseUrl}/request{i}");
+            }
+
+            // Assert - Count should exceed MaxRequestLogCount since inline trim is bypassed
+            server.LogEntries.Count().Should().BeGreaterThan(3);
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task SoftMaxEnabled_BackgroundTimerEventuallyTrimsExcess()
+    {
+        // Arrange - SoftMaxRequestLogCountEnabled = true with timer
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            MaxRequestLogCount = 3,
+            SoftMaxRequestLogCountEnabled = true
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            var baseUrl = server.Urls[0];
+
+            // Act - Send 10 requests
+            for (int i = 0; i < 10; i++)
+            {
+                await httpClient.GetAsync($"{baseUrl}/request{i}");
+            }
+
+            // Verify excess before timer fires
+            server.LogEntries.Count().Should().BeGreaterThan(3);
+
+            // Wait for background timer to fire (timer interval is 5 seconds)
+            await Task.Delay(TimeSpan.FromSeconds(7));
+
+            // Assert - Timer should have trimmed excess entries
+            server.LogEntries.Count().Should().BeLessThanOrEqualTo(3);
+        }
+        finally
+        {
+            server.Stop();
+        }
+    }
+
+    [Fact]
+    public void SoftMaxEnabled_ServerDisposesCleanly()
+    {
+        // Arrange - Start server with soft max enabled (timer running)
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            MaxRequestLogCount = 5,
+            SoftMaxRequestLogCountEnabled = true
+        });
+
+        // Act & Assert - Dispose should not throw
+        var act = () => server.Dispose();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task SoftMaxExplicitlyFalse_InlineTrimStillRunsOnEveryRequest()
+    {
+        // Arrange - SoftMaxRequestLogCountEnabled explicitly false
+        var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            MaxRequestLogCount = 3,
+            SoftMaxRequestLogCountEnabled = false
+        });
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            var baseUrl = server.Urls[0];
+
+            // Act - Send 5 requests
+            for (int i = 0; i < 5; i++)
+            {
+                await httpClient.GetAsync($"{baseUrl}/request{i}");
+            }
+
+            // Assert - Inline trim should keep count at exactly MaxRequestLogCount
+            server.LogEntries.Count().Should().Be(3);
         }
         finally
         {


### PR DESCRIPTION
Fixes for MaxRequestLogCount performance degradation
Added SoftMaxRequestLogCountEnabled flag for timer based pruning of the request log instead of checking every request - enabling a soft max instead of hard max. 