### PR TITLE
Fix WireMock Aspire startup deadlock

### DIFF
--- a/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
+++ b/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
+++ b/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     </ItemGroup>
 
 </Project>

--- a/src/WireMock.Net.Abstractions/WireMock.Net.Abstractions.csproj
+++ b/src/WireMock.Net.Abstractions/WireMock.Net.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Commonly used interfaces, models, enumerations and types.</Description>
@@ -39,10 +39,11 @@
     </ItemGroup>-->
 
     <ItemGroup>
-        <PackageReference Include="FluentBuilder" Version="0.14.0">
+        <PackageReference Include="FluentBuilder" Version="0.15.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Google.Protobuf" Version="3.35.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">

--- a/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
+++ b/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
@@ -45,7 +45,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+        <PackageReference Include="Aspire.Hosting" Version="13.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WireMock.Net.Aspire/WireMockLifecycleSubscriber.cs
+++ b/src/WireMock.Net.Aspire/WireMockLifecycleSubscriber.cs
@@ -13,7 +13,7 @@ internal class WireMockLifecycleSubscriber(ILoggerFactory loggerFactory) : IDist
 {
     public Task SubscribeAsync(IDistributedApplicationEventing eventing, DistributedApplicationExecutionContext executionContext, CancellationToken cancellationToken)
     {
-        eventing.Subscribe<ResourceEndpointsAllocatedEvent>(async (@event, ct) =>
+        eventing.Subscribe<ResourceEndpointsAllocatedEvent>((@event, ct) =>
         {
             if (@event.Resource is WireMockServerResource wireMockServerResource)
             {
@@ -22,16 +22,35 @@ internal class WireMockLifecycleSubscriber(ILoggerFactory loggerFactory) : IDist
                 var endpoint = wireMockServerResource.GetEndpoint();
                 Debug.Assert(endpoint.IsAllocated);
 
-                await wireMockServerResource.WaitForHealthAsync(ct);
-
-                await wireMockServerResource.CallAddProtoDefinitionsAsync(ct);
-
-                await wireMockServerResource.CallApiMappingBuilderActionAsync(ct);
-
-                wireMockServerResource.StartWatchingStaticMappings(ct);
+                var logger = loggerFactory.CreateLogger<WireMockLifecycleSubscriber>();
+                _ = Task.Run(() => ConfigureWireMockServerAsync(wireMockServerResource, logger, ct), CancellationToken.None);
             }
+
+            return Task.CompletedTask;
         });
 
         return Task.CompletedTask;
+    }
+
+    private static async Task ConfigureWireMockServerAsync(WireMockServerResource wireMockServerResource, ILogger logger, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await wireMockServerResource.WaitForHealthAsync(cancellationToken);
+
+            await wireMockServerResource.CallAddProtoDefinitionsAsync(cancellationToken);
+
+            await wireMockServerResource.CallApiMappingBuilderActionAsync(cancellationToken);
+
+            wireMockServerResource.StartWatchingStaticMappings(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // AppHost is stopping.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error configuring WireMock.Net resource {ResourceName}.", wireMockServerResource.Name);
+        }
     }
 }

--- a/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
+++ b/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.1" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
+++ b/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.1" />
+        <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.0" />
         <PackageReference Include="Codecov" Version="1.13.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes a WireMock Aspire startup deadlock introduced after the Aspire 13.4 upgrade.

-  `AddWireMock()` registers a lifecycle subscriber that previously awaited WireMock health and admin mapping setup inside
- `ResourceEndpointsAllocatedEvent`. In Aspire 13.4 this can block the startup event pipeline before the WireMock container has finished starting.

The fix returns from the Aspire event immediately and runs the WireMock admin setup in a background task, logging any failures instead of blocking AppHost startup.

## References

#1469 

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
