### PR TITLE
Support default port for known schemas

### DIFF
--- a/src/WireMock.Net.Minimal/Util/PortUtils.cs
+++ b/src/WireMock.Net.Minimal/Util/PortUtils.cs
@@ -1,7 +1,6 @@
 // Copyright © WireMock.Net
 
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
@@ -14,7 +13,7 @@ namespace WireMock.Util;
 /// </summary>
 internal static class PortUtils
 {
-    private static readonly Regex UrlDetailsRegex = new(@"^((?<scheme>\w+)://)(?<host>[^/]+?):(?<port>\d+)\/?$", RegexOptions.Compiled, RegexConstants.DefaultTimeout);
+    private static readonly Regex UrlDetailsRegex = new(@"^((?<scheme>\w+)://)(?<host>[^/]+?)(:(?<port>\d+))?\/?$", RegexOptions.Compiled, RegexConstants.DefaultTimeout);
 
     /// <summary>
     /// Finds a random, free port to be listened on.
@@ -90,17 +89,44 @@ internal static class PortUtils
         host = null;
         port = 0;
 
-        var match = UrlDetailsRegex.Match(url);
-        if (match.Success)
-        {
-            scheme = match.Groups["scheme"].Value;
-            isHttps = scheme.StartsWith("https", StringComparison.OrdinalIgnoreCase) || scheme.StartsWith("grpcs", StringComparison.OrdinalIgnoreCase) || scheme.StartsWith("wss", StringComparison.OrdinalIgnoreCase);
-            isHttp2 = scheme.StartsWith("grpc", StringComparison.OrdinalIgnoreCase);
-            host = match.Groups["host"].Value;
+        var urlDetails = ExtractUrlDetails(url);
 
-            return int.TryParse(match.Groups["port"].Value, out port);
+        if (urlDetails is null || urlDetails.Value.Port < 0)
+        {
+            return false;
         }
 
-        return false;
+        scheme = urlDetails.Value.Scheme;
+        isHttps = scheme.StartsWith("https", StringComparison.OrdinalIgnoreCase) || scheme.StartsWith("grpcs", StringComparison.OrdinalIgnoreCase) || scheme.StartsWith("wss", StringComparison.OrdinalIgnoreCase);
+        isHttp2 = scheme.StartsWith("grpc", StringComparison.OrdinalIgnoreCase);
+        host = urlDetails.Value.Host;
+        port = urlDetails.Value.Port;
+
+        return true;
     }
+
+    private static (string Scheme, string Host, int Port)? ExtractUrlDetails(string url)
+    {
+        var match = UrlDetailsRegex.Match(url);
+
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var scheme = match.Groups["scheme"].Value;
+        var host = match.Groups["host"].Value;
+        var port = match.Groups["port"].Success && int.TryParse(match.Groups["port"].Value, out var parsedPort)
+            ? parsedPort
+            : MapPortFromScheme(scheme);
+
+        return (scheme, host, port);
+    }
+
+    private static int MapPortFromScheme(string scheme) => scheme switch
+    {
+        "http" => 80,
+        "https" => 443,
+        _ => -1,
+    };
 }

--- a/test/WireMock.Net.Tests/Util/PortUtilsTests.cs
+++ b/test/WireMock.Net.Tests/Util/PortUtilsTests.cs
@@ -21,14 +21,14 @@ public class PortUtilsTests
         isGrpc.Should().BeFalse();
         scheme.Should().BeNull();
         host.Should().BeNull();
-        port.Should().Be(default(int));
+        port.Should().Be(default);
     }
 
     [Fact]
-    public void PortUtils_TryExtract_UrlIsMissingPort_Returns_False()
+    public void PortUtils_TryExtract_DefaultPort_UnknownScheme_Returns_False()
     {
         // Assign
-        var url = "http://0.0.0.0";
+        var url = "grpc://0.0.0.0";
 
         // Act
         var result = PortUtils.TryExtract(url, out var isHttps, out var isGrpc, out var scheme, out var host, out var port);
@@ -39,7 +39,43 @@ public class PortUtilsTests
         isGrpc.Should().BeFalse();
         scheme.Should().BeNull();
         host.Should().BeNull();
-        port.Should().Be(default(int));
+        port.Should().Be(default);
+    }
+
+    [Fact]
+    public void PortUtils_TryExtract_DefaultPort_Http_Returns_True()
+    {
+        // Assign
+        var url = "http://0.0.0.0";
+
+        // Act
+        var result = PortUtils.TryExtract(url, out var isHttps, out var isGrpc, out var scheme, out var host, out var port);
+
+        // Assert
+        result.Should().BeTrue();
+        isHttps.Should().BeFalse();
+        isGrpc.Should().BeFalse();
+        scheme.Should().Be("http");
+        host.Should().Be("0.0.0.0");
+        port.Should().Be(80);
+    }
+
+    [Fact]
+    public void PortUtils_TryExtract_DefaultPort_Https_Returns_True()
+    {
+        // Assign
+        var url = "https://0.0.0.0";
+
+        // Act
+        var result = PortUtils.TryExtract(url, out var isHttps, out var isGrpc, out var scheme, out var host, out var port);
+
+        // Assert
+        result.Should().BeTrue();
+        isHttps.Should().BeTrue();
+        isGrpc.Should().BeFalse();
+        scheme.Should().Be("https");
+        host.Should().Be("0.0.0.0");
+        port.Should().Be(443);
     }
 
     [Fact]


### PR DESCRIPTION
- Update tests which expected urls without port to fail
- Add new tests for default ports

<!-- Please describe your pull request here. -->

## References

- #1477

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
