### PR TITLE
feat(xunit logging): TestOutputHelperWireMockLogger

### DIFF
--- a/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
+++ b/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
@@ -13,7 +13,7 @@ namespace WireMock.Net.Xunit;
 /// </summary>
 public sealed class TestOutputHelperWireMockLogger : IWireMockLogger
 {
-    private readonly Func<ITestOutputHelper> _testOutputHelperFactory;
+    private readonly Func<ITestOutputHelper?> _testOutputHelperFactory;
 
     /// <summary>
     /// Create a new instance on the <see cref="TestOutputHelperWireMockLogger"/>.
@@ -29,7 +29,7 @@ public sealed class TestOutputHelperWireMockLogger : IWireMockLogger
     /// Create a new instance on the <see cref="TestOutputHelperWireMockLogger"/>.
     /// </summary>
     /// <param name="testOutputHelperFactory">Represents a factory to provide current test output.</param>
-    public TestOutputHelperWireMockLogger(Func<ITestOutputHelper> testOutputHelperFactory)
+    public TestOutputHelperWireMockLogger(Func<ITestOutputHelper?> testOutputHelperFactory)
     {
         _testOutputHelperFactory = Guard.NotNull(testOutputHelperFactory);
     }

--- a/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
+++ b/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
@@ -1,6 +1,5 @@
 // Copyright © WireMock.Net
 
-using System;
 using Newtonsoft.Json;
 using Stef.Validation;
 using WireMock.Admin.Requests;
@@ -14,51 +13,61 @@ namespace WireMock.Net.Xunit;
 /// </summary>
 public sealed class TestOutputHelperWireMockLogger : IWireMockLogger
 {
-    private readonly ITestOutputHelper _testOutputHelper;
+    private readonly Func<ITestOutputHelper> _testOutputHelperFactory;
 
     /// <summary>
     /// Create a new instance on the <see cref="TestOutputHelperWireMockLogger"/>.
     /// </summary>
     /// <param name="testOutputHelper">Represents a class which can be used to provide test output.</param>
-    public TestOutputHelperWireMockLogger(ITestOutputHelper testOutputHelper)
+    public TestOutputHelperWireMockLogger(ITestOutputHelper testOutputHelper) :
+        this(() => testOutputHelper)
     {
-        _testOutputHelper = Guard.NotNull(testOutputHelper);
+        Guard.NotNull(testOutputHelper);
+    }
+
+    /// <summary>
+    /// Create a new instance on the <see cref="TestOutputHelperWireMockLogger"/>.
+    /// </summary>
+    /// <param name="testOutputHelperFactory">Represents a factory to provide current test output.</param>
+    public TestOutputHelperWireMockLogger(Func<ITestOutputHelper> testOutputHelperFactory)
+    {
+        _testOutputHelperFactory = Guard.NotNull(testOutputHelperFactory);
     }
 
     /// <inheritdoc />
     public void Debug(string formatString, params object[] args)
     {
-        _testOutputHelper.WriteLine(Format("Debug", formatString, args));
+        _testOutputHelperFactory()?.WriteLine(Format("Debug", formatString, args));
     }
 
     /// <inheritdoc />
     public void Info(string formatString, params object[] args)
     {
-        _testOutputHelper.WriteLine(Format("Info", formatString, args));
+        _testOutputHelperFactory()?.WriteLine(Format("Info", formatString, args));
     }
 
     /// <inheritdoc />
     public void Warn(string formatString, params object[] args)
     {
-        _testOutputHelper.WriteLine(Format("Warning", formatString, args));
+        _testOutputHelperFactory()?.WriteLine(Format("Warning", formatString, args));
     }
 
     /// <inheritdoc />
     public void Error(string formatString, params object[] args)
     {
-        _testOutputHelper.WriteLine(Format("Error", formatString, args));
+        _testOutputHelperFactory()?.WriteLine(Format("Error", formatString, args));
     }
 
     /// <inheritdoc />
     public void Error(string message, Exception exception)
     {
-        _testOutputHelper.WriteLine(Format("Error", $"{message} {{0}}", exception));
+        _testOutputHelperFactory()?.WriteLine(Format("Error", $"{message} {{0}}", exception));
 
         if (exception is AggregateException ae)
         {
             ae.Handle(ex =>
             {
-                _testOutputHelper.WriteLine(Format("Error", "Exception {0}", ex));
+                _testOutputHelperFactory()?.WriteLine(Format("Error", "Exception {0}", ex));
                 return true;
             });
         }
@@ -72,7 +81,7 @@ public sealed class TestOutputHelperWireMockLogger : IWireMockLogger
             Formatting = Formatting.Indented,
             NullValueHandling = NullValueHandling.Ignore
         });
-        _testOutputHelper.WriteLine(Format("DebugRequestResponse", "Admin[{0}] {1}", isAdminRequest, message));
+        _testOutputHelperFactory()?.WriteLine(Format("DebugRequestResponse", "Admin[{0}] {1}", isAdminRequest, message));
     }
 
     private static string Format(string level, string formatString, params object[] args)


### PR DESCRIPTION
# Description
Current implementation of the `TestOutputHelperWireMockLogger` obligates me to always have ready-to-use not `null` instance of `ITestOutputHelper`. It makes it quite uncomfortable to provide logging in cases when the WireMockServer is wrapped up in a xUnit fixture.

This PR extends applications of the `TestOutputHelperWireMockLogger` by allowing it to be constructed with `Func<ITestOutputHelper>`

# Use Case
```cs
public class WireMockFixture
{
    public WireMockFixture()
    {
        WireMockServer = WireMockServer.Start(
            new WireMockServerSettings
            {
                Logger = new TestOutputHelperWireMockLogger(() => TestOutputHelper)
            });
    }

    public WireMockServer WireMockServer { get; }

    public void Dispose()
    {
        WireMockServer.Dispose();
        TestOutputHelper = null;
    }

    public ITestOutputHelper? TestOutputHelper { get; set; }
}

[CollectionDefinition(nameof(WireMockCollection))]
public class WireMockCollection : ICollectionFixture<WireMockFixture>;

[Collection(nameof(WireMockCollection))]
public class Tests
{
    public Tests(WireMockFixture fixture, ITestOutputHelper testOutputHelper)
    {
        fixture.TestOutputHelper = testOutputHelper;
    }
}
```