### PR TITLE
Fix #1492: Serialize WithClientIP matcher to Request.ClientIP

### DIFF
--- a/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
@@ -342,7 +342,7 @@ internal class MappingConverter(MatcherMapper mapper)
         if (clientIPMatcher?.Matchers != null)
         {
             var clientIPMatchers = _mapper.Map(clientIPMatcher.Matchers);
-            mappingModel.Request.Path = new ClientIPModel
+            mappingModel.Request.ClientIP = new ClientIPModel
             {
                 Matchers = clientIPMatchers,
                 MatchOperator = clientIPMatchers?.Length > 1 ? clientIPMatcher.MatchOperator.ToString() : null

--- a/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
@@ -155,7 +155,8 @@ public partial class WireMockServer
                 var clientIPModel = _settings.DefaultJsonSerializer.ParseJsonToken<ClientIPModel>(requestModel.ClientIP);
                 if (clientIPModel.Matchers != null)
                 {
-                    requestBuilder = requestBuilder.WithPath(clientIPModel.Matchers.Select(_matcherMapper.Map).OfType<IStringMatcher>().ToArray());
+                    var matchOperator = StringUtils.ParseMatchOperator(clientIPModel.MatchOperator);
+                    requestBuilder = requestBuilder.WithClientIP(matchOperator, clientIPModel.Matchers.Select(_matcherMapper.Map).OfType<IStringMatcher>().ToArray());
                 }
             }
         }

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithClientIP_And_Path_MapsClientIPToClientIPModel_NotPath.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithClientIP_And_Path_MapsClientIPToClientIPModel_NotPath.verified.txt
@@ -14,20 +14,15 @@
         }
       ]
     },
-    Headers: [
-      {
-        Name: x1,
-        Matchers: [
-          {
-            Name: WildcardMatcher,
-            Pattern: y,
-            IgnoreCase: true
-          }
-        ],
-        IgnoreCase: true
-      }
-    ],
-    EarlyMatcherType: ClientIP
+    Path: {
+      Matchers: [
+        {
+          Name: WildcardMatcher,
+          Pattern: /foo,
+          IgnoreCase: false
+        }
+      ]
+    }
   },
   Response: {},
   UseWebhooksFireAndForget: false

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithClientIP_ReturnsCorrectModel.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithClientIP_ReturnsCorrectModel.verified.txt
@@ -5,7 +5,7 @@
   Description: ,
   Priority: 42,
   Request: {
-    Path: {
+    ClientIP: {
       Matchers: [
         {
           Name: WildcardMatcher,

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.WithClientIP_And_Path_SurvivesMappingModelRoundTrip_AsClientIPMatcher.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.WithClientIP_And_Path_SurvivesMappingModelRoundTrip_AsClientIPMatcher.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    Guid: Guid_1,
+    UpdatedAt: DateTime_1,
+    Request: {
+      ClientIP: {
+        Matchers: [
+          {
+            Name: WildcardMatcher,
+            Pattern: 1.2.3.4,
+            IgnoreCase: false
+          }
+        ]
+      },
+      Path: {
+        Matchers: [
+          {
+            Name: WildcardMatcher,
+            Pattern: /foo,
+            IgnoreCase: false
+          }
+        ]
+      }
+    },
+    Response: {
+      StatusCode: 200
+    }
+  }
+]

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
@@ -6,6 +6,7 @@ using WireMock.Models;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Serialization;
+using WireMock.Server;
 using WireMock.Settings;
 using WireMock.Types;
 using WireMock.Util;
@@ -374,6 +375,47 @@ message HelloReply {
 
         // Verify
         return Verify(model);
+    }
+
+    [Fact]
+    public Task ToMappingModel_Request_WithClientIP_And_Path_MapsClientIPToClientIPModel_NotPath()
+    {
+        // Arrange: a request that gates on BOTH ClientIP and Path.
+        var request = Request.Create().WithPath("/foo").WithClientIP("1.2.3.4");
+        var response = Response.Create();
+        var mapping = new Mapping(_guid, _updatedAt, string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null, null);
+
+        // Act
+        var model = _sut.ToMappingModel(mapping);
+
+        // Assert
+        model.Should().NotBeNull();
+
+        // Verify
+        return Verify(model);
+    }
+
+    [Fact]
+    public Task WithClientIP_And_Path_SurvivesMappingModelRoundTrip_AsClientIPMatcher()
+    {
+        // Arrange: a server with a mapping that gates on BOTH ClientIP and Path.
+        using var source = WireMockServer.Start();
+        source
+            .Given(Request.Create().WithPath("/foo").WithClientIP("1.2.3.4"))
+            .RespondWith(Response.Create().WithSuccess());
+
+        var models = source.MappingModels.ToArray();
+        models.Should().ContainSingle();
+
+        // Act
+        using var target = WireMockServer.Start();
+        target.WithMapping(models);
+
+        // Assert
+        var request = (Request)target.Mappings.Single(m => !m.IsAdminInterface).RequestMatcher;
+
+        // Verify
+        return Verify(target.MappingModels);
     }
 
     [Fact]


### PR DESCRIPTION
### Problem
When a mapping that uses `WithClientIP()` is serialized to its `MappingModel`, the client‑IP matcher is not written to `Request.ClientIP`. Instead it is written to `Request.Path`.

### Root cause
- **Serialize** - `MappingConverter.ToMappingModel` assigned the client-IP matchers to `mappingModel.Request.Path`.
- **Deserialize** - `WireMockServer.ConvertMapping.InitRequestBuilder` rebuilt the object-form `Request.ClientIP` via `WithPath()` instead of `WithClientIP()`.

## References

Fixes #1492 

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
