### PR TITLE
Fix #1494: `WithClientIP(MatchOperator, params IStringMatcher[])` ignores the MatchOperator argument

### DIFF
--- a/src/WireMock.Net.Minimal/RequestBuilders/Request.ClientIP.cs
+++ b/src/WireMock.Net.Minimal/RequestBuilders/Request.ClientIP.cs
@@ -19,7 +19,7 @@ public partial class Request
     {
         Guard.NotNullOrEmpty(matchers);
 
-        _requestMatchers.Add(new RequestMessageClientIPMatcher(MatchBehaviour.AcceptOnMatch, MatchOperator.Or, matchers));
+        _requestMatchers.Add(new RequestMessageClientIPMatcher(MatchBehaviour.AcceptOnMatch, matchOperator, matchers));
         return this;
     }
 

--- a/test/WireMock.Net.Tests/RequestBuilders/RequestBuilderWithClientIPTests.cs
+++ b/test/WireMock.Net.Tests/RequestBuilders/RequestBuilderWithClientIPTests.cs
@@ -64,4 +64,23 @@ public class RequestBuilderWithClientIPTests
         var requestMatchResult = new RequestMatchResult();
         spec.GetMatchingScore(request, requestMatchResult).Should().Be(1.0);
     }
+
+    [Fact]
+    public void Request_WithClientIP_MatchOperator_And_RequiresAllMatchers()
+    {
+        // given: two matchers combined with And (the client IP must satisfy BOTH)
+        var spec = Request.Create().WithClientIP(MatchOperator.And, new WildcardMatcher("1.2.*"), new WildcardMatcher("*.3.4"));
+
+        // when: an IP matching both matchers -> perfect match
+        var matchesBoth = new RequestMessage(new UrlDetails("http://localhost"), "GET", "1.2.3.4");
+        spec.GetMatchingScore(matchesBoth, new RequestMatchResult()).Should().Be(1.0);
+
+        // when: an IP matching only the first matcher -> mismatch
+        var matchesFirstOnly = new RequestMessage(new UrlDetails("http://localhost"), "GET", "1.2.9.9");
+        spec.GetMatchingScore(matchesFirstOnly, new RequestMatchResult()).Should().Be(0.0);
+
+        // when: an IP matching only the second matcher -> mismatch
+        var matchesSecondOnly = new RequestMessage(new UrlDetails("http://localhost"), "GET", "9.3.4");
+        spec.GetMatchingScore(matchesSecondOnly, new RequestMatchResult()).Should().Be(0.0);
+    }
 }


### PR DESCRIPTION
### Problem
`WithClientIP(MatchOperator matchOperator, params IStringMatcher[] matchers)` ignored its `matchOperator` argument and always used `MatchOperator.Or`. Combining multiple client-IP matchers with `And` (or `Average`) had no effect - the request matched if any matcher matched, even when all were required.

### Tests
Added `Request_WithClientIP_MatchOperator_And_RequiresAllMatchers`: with `And`, an IP that matches only one of two matchers is a mismatch (`0.0`), and one matching both is `1.0`. 

## References

Fixes #1494

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
