### PR TITLE
Fix WithParam RejectOnMatch inverting the match result #1496

### DIFF
--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageParamMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageParamMatcher.cs
@@ -1,6 +1,5 @@
 // Copyright © WireMock.Net
 
-using System.Linq;
 using Stef.Validation;
 using WireMock.Types;
 
@@ -54,7 +53,10 @@ public class RequestMessageParamMatcher : IRequestMatcher
     /// <param name="ignoreCase">Defines if the key should be matched using case-ignore.</param>
     /// <param name="values">The values.</param>
     public RequestMessageParamMatcher(MatchBehaviour matchBehaviour, string key, bool ignoreCase, params string[]? values) :
-        this(matchBehaviour, key, ignoreCase, values?.Select(value => new ExactMatcher(matchBehaviour, ignoreCase, MatchOperator.And, value)).Cast<IStringMatcher>().ToArray())
+        // Note: the inner ExactMatcher must use AcceptOnMatch.
+        // The MatchBehaviour (e.g. RejectOnMatch) is applied once by this matcher's GetMatchingScore.
+        // Passing matchBehaviour here as well would apply the conversion twice and invert RejectOnMatch.
+        this(matchBehaviour, key, ignoreCase, values?.Select(value => new ExactMatcher(MatchBehaviour.AcceptOnMatch, ignoreCase, MatchOperator.And, value)).Cast<IStringMatcher>().ToArray())
     {
     }
 

--- a/test/WireMock.Net.Tests/RequestMatchers/RequestMessageParamMatcherTests.cs
+++ b/test/WireMock.Net.Tests/RequestMatchers/RequestMessageParamMatcherTests.cs
@@ -209,5 +209,79 @@ public class RequestMessageParamMatcherTests
         // Assert
         score.Should().Be(1.0);
     }
-}
 
+    [Fact]
+    public void RequestMessageParamMatcher_RejectOnMatch_WhenValuePresentMatchesPattern_ReturnsMismatch()
+    {
+        // Assign: the param value in the URL matches the reject pattern -> the mapping must be rejected (score 0.0).
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost?key=abc"), "GET", "127.0.0.1");
+        var matcher = new RequestMessageParamMatcher(MatchBehaviour.RejectOnMatch, "key", false, new[] { "abc" });
+
+        // Act
+        var result = new RequestMatchResult();
+        var score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(0.0d);
+    }
+
+    [Fact]
+    public void RequestMessageParamMatcher_RejectOnMatch_WhenValuePresentDoesNotMatchPattern_ReturnsPerfect()
+    {
+        // Assign: the param value in the URL does NOT match the reject pattern -> the mapping is accepted (score 1.0).
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost?key=xyz"), "GET", "127.0.0.1");
+        var matcher = new RequestMessageParamMatcher(MatchBehaviour.RejectOnMatch, "key", false, new[] { "abc" });
+
+        // Act
+        var result = new RequestMatchResult();
+        var score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(1.0d);
+    }
+
+    [Fact]
+    public void RequestMessageParamMatcher_RejectOnMatch_WithIgnoreCase_WhenValueMatchesCaseInsensitively_ReturnsMismatch()
+    {
+        // Assign: ignoreCase must still be honored on the inner matcher after the fix.
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost?key=ABC"), "GET", "127.0.0.1");
+        var matcher = new RequestMessageParamMatcher(MatchBehaviour.RejectOnMatch, "key", true, new[] { "abc" });
+
+        // Act
+        var result = new RequestMatchResult();
+        var score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(0.0d);
+    }
+
+    [Fact]
+    public void RequestMessageParamMatcher_AcceptOnMatch_WhenValuePresentMatchesPattern_ReturnsPerfect()
+    {
+        // Assign
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost?key=abc"), "GET", "127.0.0.1");
+        var matcher = new RequestMessageParamMatcher(MatchBehaviour.AcceptOnMatch, "key", false, new[] { "abc" });
+
+        // Act
+        var result = new RequestMatchResult();
+        var score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(1.0d);
+    }
+
+    [Fact]
+    public void RequestMessageParamMatcher_AcceptOnMatch_WhenValuePresentDoesNotMatchPattern_ReturnsMismatch()
+    {
+        // Assign
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost?key=xyz"), "GET", "127.0.0.1");
+        var matcher = new RequestMessageParamMatcher(MatchBehaviour.AcceptOnMatch, "key", false, new[] { "abc" });
+
+        // Act
+        var result = new RequestMatchResult();
+        var score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(0.0d);
+    }
+}

--- a/test/WireMock.Net.Tests/WireMockServerTests.WithParam.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.WithParam.cs
@@ -94,6 +94,54 @@ public partial class WireMockServerTests
     }
 
     [Fact]
+    public async Task WireMockServer_WithParam_RejectOnMatch_WithValue_WhenValueMatches_ShouldNotMatch_Returns404()
+    {
+        // Arrange
+        var cancelationToken = TestContext.Current.CancellationToken;
+        var server = WireMockServer.Start();
+        server.Given(
+            Request.Create()
+                .WithPath("/x")
+                .WithParam("k", MatchBehaviour.RejectOnMatch, "abc")
+                .UsingGet()
+            )
+            .ThenRespondWithOK();
+
+        // Act
+        var requestUri = new Uri($"http://localhost:{server.Port}/x?k=abc");
+        var response = await server.CreateClient().GetAsync(requestUri, cancelationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        server.Stop();
+    }
+
+    [Fact]
+    public async Task WireMockServer_WithParam_RejectOnMatch_WithValue_WhenValueDoesNotMatch_ShouldMatch_Returns200()
+    {
+        // Arrange
+        var cancelationToken = TestContext.Current.CancellationToken;
+        var server = WireMockServer.Start();
+        server.Given(
+            Request.Create()
+                .WithPath("/x")
+                .WithParam("k", MatchBehaviour.RejectOnMatch, "abc")
+                .UsingGet()
+            )
+            .ThenRespondWithOK();
+
+        // Act
+        var requestUri = new Uri($"http://localhost:{server.Port}/x?k=xyz");
+        var response = await server.CreateClient().GetAsync(requestUri, cancelationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        server.Stop();
+    }
+
+    [Fact]
     public async Task WireMockServer_WithParam_AcceptOnMatch_OnNonMatchingParam_ShouldReturnMappingOk()
     {
         // Arrange


### PR DESCRIPTION
## Problem
`WithParam(key, MatchBehaviour.RejectOnMatch, values)` returns the opposite result: a request whose param value equals the reject value matches (should be rejected), and a different value doesn't match (should be accepted). `AcceptOnMatch` is unaffected.

## Cause
`RequestMessageParamMatcher`'s `params string[] values` ctor injects `matchBehaviour` into each inner `ExactMatcher` (which already runs `MatchBehaviourHelper.Convert`), and `GetMatchingScore` runs `Convert` again on the aggregate - so it's applied twice.

## Fix
Create the inner `ExactMatcher` with `AcceptOnMatch`; the behaviour is now applied once by `GetMatchingScore`. `AcceptOnMatch` output is unchanged.

## Tests
- Unit: `RequestMessageParamMatcherTests` => RejectOnMatch match/non-match (+ignoreCase) and AcceptOnMatch regressions.
- E2E: `WireMockServerTests.WithParam`: `?k=abc` => 404, `?k=xyz` => 200.

## References

Fixes #1496 

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
