### PR TITLE
Update SharpYaml package to version 2.5.1

### DIFF
--- a/src/WireMock.Net.OpenApiParser/WireMock.Net.OpenApiParser.csproj
+++ b/src/WireMock.Net.OpenApiParser/WireMock.Net.OpenApiParser.csproj
@@ -54,7 +54,7 @@
         <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.43" PrivateAssets="All" />
         <PackageReference Include="Microsoft.OpenApi" Version="3.7.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.7.0" PrivateAssets="All" />
-        <PackageReference Include="SharpYaml" Version="2.1.4" />
+        <PackageReference Include="SharpYaml" Version="2.1.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## References

Upgrading Microsoft.OpenApi packages to a version which takes SharpYalm 2.1.5 with the following fix xoofx/SharpYaml#130

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)